### PR TITLE
Added a check for decoding the Genesis block.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,11 @@ fn handle_block(
     if let Some(headers_dir) = headers_dir {
         check_valid_header(&block, headers_dir)?;
     }
-    check_receipt_root(&block)?;
-    check_transaction_root(&block)?;
+    if block.number != 0 {
+        check_receipt_root(&block)?;
+        check_transaction_root(&block)?;
+    }
+    
 
     if let Some(output) = output {
         let file_name = format!("{}/block-{}.json", output, block.number);


### PR DESCRIPTION
The Genesis block needs to be verified differently than the other blocks. This PR includes a check for the Genesis block. If Genesis block, then skip transaction and receipts tree root check.  