### PR TITLE
refactor: use sf-protos type conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "sf-protos"
 version = "0.1.0"
-source = "git+https://github.com/semiotic-ai/sf-protos.git?branch=main#15062016c30ad0fc3f77c29aa2a1cb6016ece4d7"
+source = "git+https://github.com/semiotic-ai/sf-protos.git?branch=main#ed8887e1631ea882c448b3d9cfa9cd7bac85d6a3"
 dependencies = [
  "alloy-primitives",
  "ethportal-api",
@@ -4174,6 +4174,7 @@ dependencies = [
  "prost-wkt",
  "prost-wkt-build",
  "prost-wkt-types",
+ "reth-primitives",
  "serde",
  "thiserror",
 ]

--- a/src/transactions/tx_type.rs
+++ b/src/transactions/tx_type.rs
@@ -8,28 +8,7 @@ pub enum TransactionTypeError {
     Missing,
 }
 
-fn tx_to_reth_tx(tx_type: Type) -> TxType {
-    use TxType::*;
-    use Type::*;
-
-    match tx_type {
-        TrxTypeLegacy => Legacy,
-        TrxTypeAccessList => Eip2930,
-        TrxTypeDynamicFee => Eip1559,
-        TrxTypeBlob => todo!(),
-        TrxTypeArbitrumDeposit => unimplemented!(),
-        TrxTypeArbitrumUnsigned => unimplemented!(),
-        TrxTypeArbitrumContract => unimplemented!(),
-        TrxTypeArbitrumRetry => unimplemented!(),
-        TrxTypeArbitrumSubmitRetryable => unimplemented!(),
-        TrxTypeArbitrumInternal => unimplemented!(),
-        TrxTypeArbitrumLegacy => unimplemented!(),
-        TrxTypeOptimismDeposit => unimplemented!(),
-    }
-}
-
 pub fn map_tx_type(tx_type: &i32) -> Result<TxType, TransactionTypeError> {
     let tx_type = Type::try_from(*tx_type).map_err(|_| TransactionTypeError::Missing)?; // 1
-    let tx_type = tx_to_reth_tx(tx_type);
-    Ok(tx_type)
+    Ok(TxType::from(tx_type))
 }


### PR DESCRIPTION
## [TRU-269](https://linear.app/semiotic/issue/TRU-269/move-flat-files-decoder-protobuffer-tx-to-reth-tx-conversion-to-sf)